### PR TITLE
chore: promote jenkinsx-http-node to version 0.0.2

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -5,5 +5,6 @@ helmfiles:
 - path: helmfiles/nginx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
 - path: helmfiles/jx-observability/helmfile.yaml
+- path: helmfiles/jx-production/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-production
+repositories:
+- name: dev
+  url: http://bucketrepo-jx.192.168.5.15.nip.io
+releases:
+- chart: dev/jenkinsx-http-node
+  version: 0.0.2
+  name: jenkinsx-http-node
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
chore: promote jenkinsx-http-node to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
